### PR TITLE
segments as unordered_map and centroidsAsPointCloud within radius

### DIFF
--- a/laser_mapper/launch/kitti/kitti_loop_closure.yaml
+++ b/laser_mapper/launch/kitti/kitti_loop_closure.yaml
@@ -34,7 +34,7 @@ LaserMapper: {
   localize: false,
   close_loops: true,
   
-  distance_between_segmentations_m: 10.0,
+  distance_between_segmentations_m: 5.0,
 
   distance_to_lower_target_cloud_for_viz_m: 15.0,
   align_target_map_on_first_loop_closure: false,

--- a/segmatch/include/segmatch/descriptors/eigenvalue_based.hpp
+++ b/segmatch/include/segmatch/descriptors/eigenvalue_based.hpp
@@ -20,8 +20,9 @@ class EigenvalueBasedDescriptor : public Descriptor {
 
   virtual void describe(SegmentedCloud* segmented_cloud_ptr) {
     CHECK_NOTNULL(segmented_cloud_ptr);
-    for (size_t i = 0u; i < segmented_cloud_ptr->getNumberOfValidSegments(); ++i) {
-      describe(segmented_cloud_ptr->getValidSegmentPtrByIndex(i));
+    for (std::unordered_map<Id, Segment>::iterator it = segmented_cloud_ptr->begin();
+        it != segmented_cloud_ptr->end(); ++it) {
+      describe(&(it->second));
     }
   }
 

--- a/segmatch/include/segmatch/descriptors/ensemble_shape_functions.hpp
+++ b/segmatch/include/segmatch/descriptors/ensemble_shape_functions.hpp
@@ -22,8 +22,9 @@ class EnsembleShapeFunctions : public Descriptor {
 
   virtual void describe(SegmentedCloud* segmented_cloud_ptr) {
     CHECK_NOTNULL(segmented_cloud_ptr);
-    for (size_t i = 0u; i < segmented_cloud_ptr->getNumberOfValidSegments(); ++i) {
-      describe(segmented_cloud_ptr->getValidSegmentPtrByIndex(i));
+    for (std::unordered_map<Id, Segment>::iterator it = segmented_cloud_ptr->begin();
+        it != segmented_cloud_ptr->end(); ++it) {
+      describe(&(it->second));
     }
   }
 

--- a/segmatch/include/segmatch/segmented_cloud.hpp
+++ b/segmatch/include/segmatch/segmented_cloud.hpp
@@ -139,7 +139,6 @@ class SegmentedCloud {
                                    double maximum_linkpose_distance,
                                    std::vector<Id>* segment_id_for_each_point_ptr=NULL) const;
 
-
   bool findNearestSegmentsToPoint(const PclPoint& point,
                                   unsigned int n_closest_segments,
                                   double maximum_centroid_distance_m,

--- a/segmatch/include/segmatch/segmented_cloud.hpp
+++ b/segmatch/include/segmatch/segmented_cloud.hpp
@@ -3,6 +3,7 @@
 
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <glog/logging.h>
@@ -89,31 +90,23 @@ class SegmentedCloud {
   SegmentedCloud() {};
   Id getNextId(const Id& begin_counting_from_this_id = 0);
   SegmentedCloud& operator+= (const SegmentedCloud& rhs) {
-    for (size_t i = 0u; i < rhs.getNumberOfValidSegments(); ++i) {
-      this->addValidSegment(rhs.getValidSegmentByIndex(i));
+    for (auto& id_segment: rhs.valid_segments_) {
+      this->addValidSegment(id_segment.second);
     }
     return *this;
   }
   void addSegmentedCloud(const SegmentedCloud& segmented_cloud_to_add);
-  void addSegmentsTo(const pcl::IndicesClusters& segments_to_add,
-                     const pcl::PointCloud<pcl::PointNormal>& reference_cloud,
-                     std::vector<Segment>* target_cluster_ptr,
-                     const bool also_copy_normals_data=true);
+  void addSegments(const pcl::IndicesClusters& segments_to_add,
+                   const pcl::PointCloud<pcl::PointNormal>& reference_cloud,
+                   const bool also_copy_normals_data=true);
   void addValidSegments(const pcl::IndicesClusters& segments_to_add,
-                        const pcl::PointCloud<pcl::PointNormal>& reference_cloud);
-  void addSmallSegments(const pcl::IndicesClusters& segments_to_add,
-                        const pcl::PointCloud<pcl::PointNormal>& reference_cloud);
-  void addLargeSegments(const pcl::IndicesClusters& segments_to_add,
                         const pcl::PointCloud<pcl::PointNormal>& reference_cloud);
   /// \brief Adds a copy of a segment to this cloud.
   ///        This causes two segments to exist with the same Id.
   void addValidSegment(const Segment& segment_to_add);
   size_t getNumberOfValidSegments() const;
   bool empty() const { return getNumberOfValidSegments() == 0; }
-  bool findValidSegmentById(const Id segment_id, Segment* result, size_t* index=NULL) const;
-  bool findValidSegmentPtrById(const Id segment_id, Segment** result, size_t* index=NULL);
-  Segment getValidSegmentByIndex(const size_t index) const;
-  Segment* getValidSegmentPtrByIndex(const size_t index);
+  bool findValidSegmentById(const Id segment_id, Segment* result) const;
   void deleteSegmentsById(const std::vector<Id>& ids, size_t* n_removals=NULL);
   bool computeSegmentOverlaps(const SegmentedCloud& target_segmented_cloud,
                               const float overlap_radius,
@@ -122,20 +115,11 @@ class SegmentedCloud {
                               Overlaps* overlaps) const;
   /// brief Clear the segmented cloud.
   void clear();
-  Id getLargestId() const {
-    if (getNumberOfValidSegments() == 0u) {
-      return kNoId;
-    } else {
-      // TODO(daniel) ensure this remains true if segments are no longer sorted.
-      return getValidSegmentByIndex(getNumberOfValidSegments()-1).segment_id;
-    }
-  }
   void calculateSegmentCentroids();
   void transform(const Eigen::Matrix4f& transform_matrix) {
-    for (size_t i = 0u; i < getNumberOfValidSegments(); ++i) {
-      Segment* segment_ptr = getValidSegmentPtrByIndex(i);
-      pcl::transformPointCloud(segment_ptr->point_cloud,
-                               segment_ptr->point_cloud,
+    for (auto& id_segment: valid_segments_) {
+      pcl::transformPointCloud(id_segment.second.point_cloud,
+                               id_segment.second.point_cloud,
                                transform_matrix);
     }
     calculateSegmentCentroids(); // TODO: is transforming the centroids faster?
@@ -149,6 +133,12 @@ class SegmentedCloud {
       std::vector<Id>* segment_id_for_each_point_ptr=NULL) const;
   PointCloud centroidsAsPointCloud(
       std::vector<Id>* segment_id_for_each_point_ptr=NULL) const;
+
+  // Get the centroids which linkpose falls within a radius.
+  PointCloud centroidsAsPointCloud(const laser_slam::SE3& center,
+                                   double maximum_linkpose_distance,
+                                   std::vector<Id>* segment_id_for_each_point_ptr=NULL) const;
+
 
   bool findNearestSegmentsToPoint(const PclPoint& point,
                                   unsigned int n_closest_segments,
@@ -168,12 +158,24 @@ class SegmentedCloud {
 
   void updateSegments(const std::vector<laser_slam::Trajectory>& trajectories);
 
+  std::unordered_map<Id, Segment>::const_iterator begin() const {
+    return valid_segments_.begin();
+  }
 
-  // TODO(daniel) delete.
-  std::vector<Segment> small_segments_;
-  std::vector<Segment> large_segments_;
+  std::unordered_map<Id, Segment>::const_iterator end() const {
+    return valid_segments_.end();
+  }
+
+  std::unordered_map<Id, Segment>::iterator begin() {
+    return valid_segments_.begin();
+  }
+
+  std::unordered_map<Id, Segment>::iterator end() {
+    return valid_segments_.end();
+  }
+
  private:
-  std::vector<Segment> valid_segments_;
+  std::unordered_map<Id, Segment> valid_segments_;
 }; // class SegmentedCloud
 
 //TODO Move inside of SegmentedCloud? eg. validSegmentsAsColoredCloud().
@@ -187,16 +189,17 @@ static void segmentedCloudToCloud(const SegmentedCloud& segmented_cloud,
     permuted_indexes.push_back(i);
   }
   std::random_shuffle(permuted_indexes.begin(), permuted_indexes.end());
-  for (size_t i = 0u; i < segmented_cloud.getNumberOfValidSegments(); ++i) {
-    PointICloud segment_cloud =
-        segmented_cloud.getValidSegmentByIndex(i).point_cloud;
+  unsigned int i = 0u;
+  for (std::unordered_map<Id, Segment>::const_iterator it = segmented_cloud.begin();
+      it != segmented_cloud.end(); ++it) {
+    PointICloud segment_cloud = it->second.point_cloud;
     // Color Segment Cloud.
     for (size_t j = 0u; j < segment_cloud.size(); ++j) {
       segment_cloud.points[j].intensity = permuted_indexes[i];
     }
     cloud += segment_cloud;
+    ++i;
   }
-
   cloud.width = 1;
   cloud.height = cloud.points.size();
 

--- a/segmatch/src/opencv_random_forest.cpp
+++ b/segmatch/src/opencv_random_forest.cpp
@@ -7,7 +7,8 @@ using namespace Eigen;
 using namespace cv;
 using namespace segmatch;
 
-void convertEigenToOpenCvMat(const Eigen::MatrixXd& eigen_mat, Mat* open_cv_mat) {
+void convertEigenToOpenCvMat(const Eigen::MatrixXd& eigen_mat,
+                             Mat* open_cv_mat) {
   CHECK_NOTNULL(open_cv_mat);
   for (size_t i = 0u; i < eigen_mat.rows(); ++i) {
     for (size_t j = 0u; j < eigen_mat.cols(); ++j) {
@@ -18,23 +19,29 @@ void convertEigenToOpenCvMat(const Eigen::MatrixXd& eigen_mat, Mat* open_cv_mat)
 
 namespace segmatch {
 
-OpenCvRandomForest::OpenCvRandomForest(const ClassifierParams& params) : params_(params) {
+OpenCvRandomForest::OpenCvRandomForest(const ClassifierParams& params)
+    : params_(params) {
   rtrees_.load(params.classifier_filename.c_str());
 
-  inverted_max_eigen_double_.resize(1,7);
-  inverted_max_eigen_float_.resize(1,7);
+  inverted_max_eigen_double_.resize(1, 7);
+  inverted_max_eigen_float_.resize(1, 7);
   for (int i = 0; i < 7; ++i) {
-    inverted_max_eigen_double_(0,i) = 1.0/params.max_eigen_features_values[i];
-    inverted_max_eigen_float_(0,i) = float(1.0/params.max_eigen_features_values[i]);
+    inverted_max_eigen_double_(0, i) = 1.0
+        / params.max_eigen_features_values[i];
+    inverted_max_eigen_float_(0, i) = float(
+        1.0 / params.max_eigen_features_values[i]);
   }
-  std::cout << "inverted_max_eigen_double_ " << std::endl << inverted_max_eigen_double_ << std::endl;
-  std::cout << "inverted_max_eigen_float_ " << std::endl << inverted_max_eigen_float_ << std::endl;
+  std::cout << "inverted_max_eigen_double_ " << std::endl
+            << inverted_max_eigen_double_ << std::endl;
+  std::cout << "inverted_max_eigen_float_ " << std::endl
+            << inverted_max_eigen_float_ << std::endl;
 }
 
-OpenCvRandomForest::~OpenCvRandomForest() {}
+OpenCvRandomForest::~OpenCvRandomForest() {
+}
 
 void OpenCvRandomForest::resetParams(const ClassifierParams& params) {
-  LOG(INFO) << "Reset classifier parameters.";
+  LOG(INFO)<< "Reset classifier parameters.";
   LOG(INFO) << "n_nearest_neighbours: " << params_.n_nearest_neighbours;
   LOG(INFO) << "enable_two_stage_retrieval: " << params_.enable_two_stage_retrieval;
   LOG(INFO) << "knn_feature_dim: " << params_.knn_feature_dim;
@@ -50,11 +57,11 @@ void histogramIntersection(const Eigen::MatrixXd& h1, const Eigen::MatrixXd& h2,
   CHECK_EQ(h1.cols(), h2.cols());
   CHECK_EQ(h1.rows(), h2.rows());
   /*for (size_t i = 0u; i < h1.cols(); ++i) {
-    CHECK_GE(h1(0, i), 0);
-    CHECK_GE(h2(0, i), 0);
+   CHECK_GE(h1(0, i), 0);
+   CHECK_GE(h2(0, i), 0);
 
-    intersection += std::min(h1(0, i), h2(0, i));
-  }*/
+   intersection += std::min(h1(0, i), h2(0, i));
+   }*/
 
   *intersection = (h1 + h2 - (h1 - h2).cwiseAbs()).rowwise().sum() / 2.0;
 }
@@ -117,7 +124,7 @@ void OpenCvRandomForest::computeFeaturesDistance(const Eigen::MatrixXd& f1,
           histogramIntersection(h1.block(0, i * bin_size, n_sample, bin_size),
                                 h2.block(0, i * bin_size, n_sample, bin_size),
                                 &intersection);
-          f.block(0,i,n_sample,1) = intersection;
+          f.block(0, i, n_sample, 1) = intersection;
         }
 
         fs.push_back(f);
@@ -138,8 +145,9 @@ void OpenCvRandomForest::computeFeaturesDistance(const Eigen::MatrixXd& f1,
   }
 }
 
-PairwiseMatches OpenCvRandomForest::findCandidates(const SegmentedCloud& source_cloud,
-                                                   PairwiseMatches* matches_after_first_stage) {
+PairwiseMatches OpenCvRandomForest::findCandidates(
+    const SegmentedCloud& source_cloud,
+    PairwiseMatches* matches_after_first_stage) {
   laser_slam::Clock clock;
   if (matches_after_first_stage != NULL) {
     matches_after_first_stage->clear();
@@ -147,8 +155,9 @@ PairwiseMatches OpenCvRandomForest::findCandidates(const SegmentedCloud& source_
   PairwiseMatches candidates;
   PairwiseMatches candidates_after_first_stage;
 
-  if (target_cloud_.empty() ||
-      target_cloud_.getNumberOfValidSegments() < kMinNumberSegmentInTargetCloud) {
+  if (target_cloud_.empty()
+      || target_cloud_.getNumberOfValidSegments()
+          < kMinNumberSegmentInTargetCloud) {
     return candidates;
   }
 
@@ -156,36 +165,40 @@ PairwiseMatches OpenCvRandomForest::findCandidates(const SegmentedCloud& source_
 
   if (params_.n_nearest_neighbours > 0 && params_.enable_two_stage_retrieval) {
     if (params_.apply_hard_threshold_on_feature_distance) {
-      LOG(INFO) << "Two stage retrieval with hard threshold and " <<
-          target_cloud_.getNumberOfValidSegments() << " segments in the target cloud.";
+      LOG(INFO)<< "Two stage retrieval with hard threshold and " <<
+      target_cloud_.getNumberOfValidSegments() << " segments in the target cloud.";
     } else {
       LOG(INFO) << "Two stage retrieval with RF and " <<
-          target_cloud_.getNumberOfValidSegments() << " segments in the target cloud.";
+      target_cloud_.getNumberOfValidSegments() << " segments in the target cloud.";
     }
   } else if (params_.n_nearest_neighbours > 0) {
     LOG(INFO) << "Finding candidates with libnabo knn and " <<
-        target_cloud_.getNumberOfValidSegments() << " segments in the target cloud.";
+    target_cloud_.getNumberOfValidSegments() << " segments in the target cloud.";
   } else {
     LOG(INFO) << "Finding candidates with RF and " <<
-        target_cloud_.getNumberOfValidSegments() << " segments in the target cloud.";
+    target_cloud_.getNumberOfValidSegments() << " segments in the target cloud.";
   }
 
   if (params_.n_nearest_neighbours > 0) {
-    for (size_t i = 0u; i < source_cloud.getNumberOfValidSegments(); ++i) {
-      Segment source_segment = source_cloud.getValidSegmentByIndex(i);
+
+    for (std::unordered_map<Id, Segment>::const_iterator it_source = source_cloud.begin();
+        it_source != source_cloud.end(); ++it_source) {
+      Segment source_segment = it_source->second;
       Eigen::MatrixXd features_source = source_segment.features.asEigenMatrix();
 
       VectorXf q;
       if (params_.normalize_eigen_for_knn) {
         Eigen::MatrixXd features_source_normalized = features_source;
         normalizeEigenFeatures(&features_source_normalized);
-        q = features_source_normalized.block(0,0,1,params_.knn_feature_dim).transpose().cast<float>();
+        q = features_source_normalized.block(0, 0, 1, params_.knn_feature_dim)
+            .transpose().cast<float>();
       } else {
-        q = features_source.block(0,0,1,params_.knn_feature_dim).transpose().cast<float>();
+        q = features_source.block(0, 0, 1, params_.knn_feature_dim).transpose()
+            .cast<float>();
       }
 
       const unsigned int n_nearest_neighbours = std::min(
-          params_.n_nearest_neighbours, int(target_segment_ids_.size())-1);
+          params_.n_nearest_neighbours, int(target_segment_ids_.size()) - 1);
       VectorXi indices(n_nearest_neighbours);
       VectorXf dists2(n_nearest_neighbours);
       nns_->knn(q, indices, dists2, n_nearest_neighbours);
@@ -201,9 +214,11 @@ PairwiseMatches OpenCvRandomForest::findCandidates(const SegmentedCloud& source_
         candidates_after_first_stage.push_back(match);
       }
     }
+
     if (matches_after_first_stage != NULL) {
       *matches_after_first_stage = candidates_after_first_stage;
     }
+
     if (params_.enable_two_stage_retrieval) {
 
       if (params_.apply_hard_threshold_on_feature_distance) {
@@ -225,14 +240,17 @@ PairwiseMatches OpenCvRandomForest::findCandidates(const SegmentedCloud& source_
       } else {
         // Two stage knn and RF.
 
-        const unsigned int feature_dimension = candidates_after_first_stage[0].features1_.cols();
-        Eigen::MatrixXd F1(candidates_after_first_stage.size(), feature_dimension);
-        Eigen::MatrixXd F2(candidates_after_first_stage.size(), feature_dimension);
+        const unsigned int feature_dimension = candidates_after_first_stage[0]
+            .features1_.cols();
+        Eigen::MatrixXd F1(candidates_after_first_stage.size(),
+                           feature_dimension);
+        Eigen::MatrixXd F2(candidates_after_first_stage.size(),
+                           feature_dimension);
 
         for (size_t i = 0u; i < candidates_after_first_stage.size(); ++i) {
           PairwiseMatch candidate = candidates_after_first_stage[i];
-          F1.block(i,0,1,feature_dimension) = candidate.features1_;
-          F2.block(i,0,1,feature_dimension) = candidate.features2_;
+          F1.block(i, 0, 1, feature_dimension) = candidate.features1_;
+          F2.block(i, 0, 1, feature_dimension) = candidate.features2_;
         }
 
         Eigen::MatrixXd dF;
@@ -242,15 +260,16 @@ PairwiseMatches OpenCvRandomForest::findCandidates(const SegmentedCloud& source_
         for (size_t i = 0u; i < candidates_after_first_stage.size(); ++i) {
           PairwiseMatch candidate = candidates_after_first_stage[i];
           Mat features(1, feature_dim_after_dist, CV_32FC1);
-          convertEigenToOpenCvMat(dF.block(i,0,1,feature_dim_after_dist), &features);
+          convertEigenToOpenCvMat(dF.block(i, 0, 1, feature_dim_after_dist),
+                                  &features);
           const float confidence = rtrees_.predict_prob(features);
           if (confidence > params_.threshold_to_accept_match) {
-            candidates.push_back(PairwiseMatch(candidate.ids_.first, candidate.ids_.second,
-                                               candidate.centroids_.first, candidate.centroids_.second,
-                                               confidence));
+            candidates.push_back(
+                PairwiseMatch(candidate.ids_.first, candidate.ids_.second,
+                              candidate.centroids_.first,
+                              candidate.centroids_.second, confidence));
           }
         }
-
 
         //        for (size_t i = 0u; i < candidates_after_first_stage.size(); ++i) {
         //          PairwiseMatch candidate = candidates_after_first_stage[i];
@@ -274,34 +293,39 @@ PairwiseMatches OpenCvRandomForest::findCandidates(const SegmentedCloud& source_
     }
   } else {
     // RF only.
-    for (size_t i = 0u; i < source_cloud.getNumberOfValidSegments(); ++i) {
-      Segment source_segment = source_cloud.getValidSegmentByIndex(i);
+    for (std::unordered_map<Id, Segment>::const_iterator it_source = source_cloud.begin();
+        it_source != source_cloud.end(); ++it_source) {
+      Segment source_segment = it_source->second;
       Eigen::MatrixXd features_source = source_segment.features.asEigenMatrix();
 
-      for (size_t j = 0u; j < target_cloud_.getNumberOfValidSegments(); ++j) {
-        Segment target_segment = target_cloud_.getValidSegmentByIndex(j);
-        Eigen::MatrixXd features_target = target_segment.features.asEigenMatrix();
+      for (std::unordered_map<Id, Segment>::const_iterator it_target = target_cloud_.begin();
+          it_target != source_cloud.end(); ++it_target) {
+        Segment target_segment = it_target->second;
+        Eigen::MatrixXd features_target =
+            target_segment.features.asEigenMatrix();
 
         Eigen::MatrixXd diff_features;
-        computeFeaturesDistance(features_source, features_target, &diff_features);
+        computeFeaturesDistance(features_source, features_target,
+                                &diff_features);
 
         Mat features(1, diff_features.cols(), CV_32FC1);
         convertEigenToOpenCvMat(diff_features, &features);
 
         const float confidence = rtrees_.predict_prob(features);
         if (confidence > params_.threshold_to_accept_match) {
-          candidates.push_back(PairwiseMatch(source_segment.segment_id, target_segment.segment_id,
-                                             source_segment.centroid, target_segment.centroid,
-                                             confidence));
+          candidates.push_back(
+              PairwiseMatch(source_segment.segment_id,
+                            target_segment.segment_id, source_segment.centroid,
+                            target_segment.centroid, confidence));
         }
       }
     }
   }
 
   clock.takeTime();
-  LOG(INFO) << "Found " << candidates.size() << " candidates in "
-      << clock.getRealTime() << "ms with " << time_in_compute_distance <<
-      " ms in computing distance." << std::endl;
+  LOG(INFO)<< "Found " << candidates.size() << " candidates in "
+  << clock.getRealTime() << "ms with " << time_in_compute_distance <<
+  " ms in computing distance." << std::endl;
   return candidates;
 }
 
@@ -309,8 +333,8 @@ void OpenCvRandomForest::train(const Eigen::MatrixXd& features,
                                const Eigen::MatrixXd& labels) {
   const unsigned int n_training_samples = features.rows();
   const unsigned int descriptors_dimension = features.cols();
-  LOG(INFO) << "Training RF with " << n_training_samples << " of dimension "
-      << descriptors_dimension << ".";
+  LOG(INFO)<< "Training RF with " << n_training_samples << " of dimension "
+  << descriptors_dimension << ".";
 
   Mat opencv_features(n_training_samples, descriptors_dimension, CV_32FC1);
   Mat opencv_labels(n_training_samples, 1, CV_32FC1);
@@ -322,32 +346,27 @@ void OpenCvRandomForest::train(const Eigen::MatrixXd& features,
     opencv_labels.at<float>(i, 0) = labels(i, 0);
   }
 
-  float priors[] = {params_.rf_priors[0], params_.rf_priors[1]};
+  float priors[] = { params_.rf_priors[0], params_.rf_priors[1] };
 
   // Random forest parameters.
-  CvRTParams rtrees_params = CvRTParams(params_.rf_max_depth,
-                                        params_.rf_min_sample_ratio *
-                                        n_training_samples,
-                                        params_.rf_regression_accuracy,
-                                        params_.rf_use_surrogates,
-                                        params_.rf_max_categories,
-                                        priors,
-                                        params_.rf_calc_var_importance,
-                                        params_.rf_n_active_vars,
-                                        params_.rf_max_num_of_trees,
-                                        params_.rf_accuracy,
-                                        CV_TERMCRIT_EPS);
+  CvRTParams rtrees_params = CvRTParams(
+      params_.rf_max_depth, params_.rf_min_sample_ratio * n_training_samples,
+      params_.rf_regression_accuracy, params_.rf_use_surrogates,
+      params_.rf_max_categories, priors, params_.rf_calc_var_importance,
+      params_.rf_n_active_vars, params_.rf_max_num_of_trees,
+      params_.rf_accuracy,
+      CV_TERMCRIT_EPS);
 
-  rtrees_.train(opencv_features, CV_ROW_SAMPLE, opencv_labels,
-                cv::Mat(), cv::Mat(), cv::Mat(), cv::Mat(), rtrees_params);
+  rtrees_.train(opencv_features, CV_ROW_SAMPLE, opencv_labels, cv::Mat(),
+                cv::Mat(), cv::Mat(), cv::Mat(), rtrees_params);
   ROS_INFO_STREAM("Tree count: " << rtrees_.get_tree_count() << ".");
 
   if (params_.rf_calc_var_importance) {
     Mat variable_importance = rtrees_.getVarImportance();
     Size variable_importance_size = variable_importance.size();
-    CHECK_EQ(variable_importance_size.height, 1.0) << "Height of variable importance is not 1.";
-    CHECK_EQ(variable_importance_size.width, descriptors_dimension) <<
-        "Width of variable importance is the features dimension.";
+    CHECK_EQ(variable_importance_size.height, 1.0)<< "Height of variable importance is not 1.";
+    CHECK_EQ(variable_importance_size.width, descriptors_dimension)<<
+    "Width of variable importance is the features dimension.";
 
     // TODO(renaud): Remove this cout (just for debugging).
     std::cout << "Variable importance: ";
@@ -362,12 +381,12 @@ void OpenCvRandomForest::train(const Eigen::MatrixXd& features,
 
 void OpenCvRandomForest::test(const Eigen::MatrixXd& features,
                               const Eigen::MatrixXd& labels,
-                              Eigen::MatrixXd* probabilities)  const {
+                              Eigen::MatrixXd* probabilities) const {
   laser_slam::Clock clock;
   const unsigned int n_samples = features.rows();
   const unsigned int descriptors_dimension = features.cols();
-  LOG(INFO) << "Testing the random forest with " << n_samples
-      << " samples of dimension " << descriptors_dimension << ".";
+  LOG(INFO)<< "Testing the random forest with " << n_samples
+  << " samples of dimension " << descriptors_dimension << ".";
 
   if (probabilities != NULL) {
     probabilities->resize(n_samples, 1);
@@ -395,27 +414,29 @@ void OpenCvRandomForest::test(const Eigen::MatrixXd& features,
         }
       }
       if (probabilities != NULL) {
-        (*probabilities)(i,0) = probability;
+        (*probabilities)(i, 0) = probability;
       }
     }
     displayPerformances(tp, tn, fp, fn);
   }
   clock.takeTime();
-  LOG(INFO) << "Took " << clock.getRealTime() << "ms to test.";
+  LOG(INFO)<< "Took " << clock.getRealTime() << "ms to test.";
 }
 
 void OpenCvRandomForest::save(const std::string& filename) const {
-  LOG(INFO) << "Saving the classifier to: " << filename << ".";
+  LOG(INFO)<< "Saving the classifier to: " << filename << ".";
   rtrees_.save(filename.c_str());
 }
 
 void OpenCvRandomForest::load(const std::string& filename) {
-  LOG(INFO) << "Loading a classifier from: " << filename << ".";
+  LOG(INFO)<< "Loading a classifier from: " << filename << ".";
   rtrees_.load(filename.c_str());
 }
 
 void OpenCvRandomForest::setTarget(const SegmentedCloud& target_cloud) {
-  if (target_cloud.empty()) { return; }
+  if (target_cloud.empty()) {
+    return;
+  }
 
   target_cloud_ = target_cloud;
 
@@ -423,15 +444,20 @@ void OpenCvRandomForest::setTarget(const SegmentedCloud& target_cloud) {
   target_segment_centroids_.clear();
   target_segment_features_.clear();
 
-  target_matrix_.resize(target_cloud.getNumberOfValidSegments(),params_.knn_feature_dim);
+  target_matrix_.resize(target_cloud.getNumberOfValidSegments(),
+                        params_.knn_feature_dim);
 
-  for (size_t j = 0u; j < target_cloud.getNumberOfValidSegments(); ++j) {
-    Segment target_segment = target_cloud.getValidSegmentByIndex(j);
-    target_matrix_.block(j, 0, 1, params_.knn_feature_dim) =
-        target_segment.features.asEigenMatrix().block(0, 0, 1, params_.knn_feature_dim).cast<float>();
+  unsigned int i = 0u;
+  for (std::unordered_map<Id, Segment>::const_iterator it = target_cloud.begin();
+      it != target_cloud.end(); ++it) {
+    Segment target_segment = it->second;
+    target_matrix_.block(i, 0, 1, params_.knn_feature_dim) = target_segment
+        .features.asEigenMatrix().block(0, 0, 1, params_.knn_feature_dim)
+        .cast<float>();
     target_segment_ids_.push_back(target_segment.segment_id);
     target_segment_centroids_.push_back(target_segment.centroid);
     target_segment_features_.push_back(target_segment.features.asEigenMatrix());
+    ++i;
   }
 
   if (params_.normalize_eigen_for_knn) {
@@ -444,15 +470,16 @@ void OpenCvRandomForest::setTarget(const SegmentedCloud& target_cloud) {
 
 void OpenCvRandomForest::normalizeEigenFeatures(Eigen::MatrixXd* f) {
   for (size_t i = 0u; i < f->rows(); ++i) {
-    f->block(i,0,1,7) = f->block(i,0,1,7).cwiseProduct(inverted_max_eigen_double_);
+    f->block(i, 0, 1, 7) = f->block(i, 0, 1, 7).cwiseProduct(
+        inverted_max_eigen_double_);
   }
 }
 
 void OpenCvRandomForest::normalizeEigenFeatures(Eigen::MatrixXf* f) {
   for (size_t i = 0u; i < f->rows(); ++i) {
-    f->block(i,0,1,7) = f->block(i,0,1,7).cwiseProduct(inverted_max_eigen_float_);
+    f->block(i, 0, 1, 7) = f->block(i, 0, 1, 7).cwiseProduct(
+        inverted_max_eigen_float_);
   }
 }
 
-
-} // namespace segmatch
+}  // namespace segmatch

--- a/segmatch/src/segmatch.cpp
+++ b/segmatch/src/segmatch.cpp
@@ -482,11 +482,6 @@ void SegMatch::filterDuplicateSegmentsOfTargetMap(const SegmentedCloud& cloud_to
         params_.segmentation_radius_m * 3.0,
         &target_segment_ids);
 
-    clock.takeTime();
-    LOG(INFO) << "Creating cloud for duplicates removal took " <<
-        clock.getRealTime() << " ms.";
-    clock.start();
-
     const unsigned int n_nearest_segments = 1u;
     if (target_segment_ids.size() > n_nearest_segments) {
       // Set up nearest neighbour search.
@@ -512,11 +507,6 @@ void SegMatch::filterDuplicateSegmentsOfTargetMap(const SegmentedCloud& cloud_to
         }
       }
     }
-
-    clock.takeTime();
-    LOG(INFO) << "Finding nn took " <<
-        clock.getRealTime() << " ms.";
-    clock.start();
 
     // Remove duplicates.
     size_t n_removals;

--- a/segmatch/src/segmented_cloud.cpp
+++ b/segmatch/src/segmented_cloud.cpp
@@ -1,6 +1,7 @@
 #include "segmatch/segmented_cloud.hpp"
 
 #include <cfenv>
+#include <utility>
 
 namespace segmatch {
 
@@ -99,17 +100,14 @@ Id SegmentedCloud::getNextId(const Id& begin_counting_from_this_id) {
 
 void SegmentedCloud::addSegmentedCloud(const SegmentedCloud& segmented_cloud_to_add) {
   if (!segmented_cloud_to_add.empty()) {
-    for (size_t i = 0u; i < segmented_cloud_to_add.getNumberOfValidSegments(); ++i) {
-      addValidSegment(segmented_cloud_to_add.getValidSegmentByIndex(i));
-    }
+    valid_segments_.insert(segmented_cloud_to_add.valid_segments_.begin(),
+                           segmented_cloud_to_add.valid_segments_.end());
   }
 }
 
-void SegmentedCloud::addSegmentsTo(const pcl::IndicesClusters& segments_to_add,
-                                   const pcl::PointCloud<pcl::PointNormal>& reference_cloud,
-                                   std::vector<Segment>* target_cluster_ptr,
-                                   const bool also_copy_normals_data) {
-  CHECK_NOTNULL(target_cluster_ptr);
+void SegmentedCloud::addSegments(const pcl::IndicesClusters& segments_to_add,
+                                 const pcl::PointCloud<pcl::PointNormal>& reference_cloud,
+                                 const bool also_copy_normals_data) {
   // Loop over clusters.
   for (size_t i = 0u; i < segments_to_add.size(); ++i) {
     std::vector<int> indices = segments_to_add[i].indices;
@@ -118,11 +116,7 @@ void SegmentedCloud::addSegmentsTo(const pcl::IndicesClusters& segments_to_add,
     Segment segment;
 
     // Assign the segment an id.
-    if (target_cluster_ptr == &valid_segments_) {
-      segment.segment_id = getNextId();
-    } else {
-      segment.segment_id = kInvId;
-    }
+    segment.segment_id = getNextId();
 
     // Copy points into segment.
     for (size_t j = 0u; j < indices.size(); ++j) {
@@ -164,109 +158,71 @@ void SegmentedCloud::addSegmentsTo(const pcl::IndicesClusters& segments_to_add,
     }
 
     segment.calculateCentroid();
-    target_cluster_ptr->push_back(segment);
+    valid_segments_.insert(std::make_pair(segment.segment_id, segment));
   }
 }
 
 void SegmentedCloud::addValidSegments(const pcl::IndicesClusters& segments_to_add,
                                       const pcl::PointCloud<pcl::PointNormal>& reference_cloud) {
-  addSegmentsTo(segments_to_add, reference_cloud, &valid_segments_);
-}
-
-void SegmentedCloud::addSmallSegments(const pcl::IndicesClusters& segments_to_add,
-                                      const pcl::PointCloud<pcl::PointNormal>& reference_cloud) {
-  addSegmentsTo(segments_to_add, reference_cloud, &small_segments_);
-}
-
-void SegmentedCloud::addLargeSegments(const pcl::IndicesClusters& segments_to_add,
-                                      const pcl::PointCloud<pcl::PointNormal>& reference_cloud) {
-  addSegmentsTo(segments_to_add, reference_cloud, &large_segments_);
+  addSegments(segments_to_add, reference_cloud);
 }
 
 void SegmentedCloud::addValidSegment(const Segment& segment_to_add) {
   CHECK(segment_to_add.hasValidId());
-  valid_segments_.push_back(segment_to_add);
+  valid_segments_.insert(std::make_pair(segment_to_add.segment_id, segment_to_add));
 }
 
 size_t SegmentedCloud::getNumberOfValidSegments() const {
   return valid_segments_.size();
 }
 
-bool SegmentedCloud::findValidSegmentById(const Id segment_id, Segment* result,
-                                          size_t* index_ptr) const {
-  for (size_t i = 0u; i < getNumberOfValidSegments(); ++i) {
-    if (getValidSegmentByIndex(i).segment_id == segment_id) {
-      if (result != NULL) {
-        *result = valid_segments_.at(i);
-      }
-      // If desired, pass the segment's index.
-      if (index_ptr != NULL) {
-        *index_ptr = i;
-      }
-      return true;
+bool SegmentedCloud::findValidSegmentById(const Id segment_id, Segment* result) const {
+  if (valid_segments_.count(segment_id)) {
+    if (result != NULL) {
+      *result = valid_segments_.at(segment_id);
     }
+    return true;
+  } else {
+    return false;
   }
-  return false;
-}
-
-bool SegmentedCloud::findValidSegmentPtrById(const Id segment_id, Segment** result,
-                                             size_t* index_ptr) {
-  // Find the index of the segment using already-existing code.
-  size_t index;
-  if (!findValidSegmentById(segment_id, NULL, &index)) { return false; }
-  // If desired, pass the index.
-  if (index_ptr != NULL) { *index_ptr = index; }
-  // If desired, pass the segment ptr.
-  if (result != NULL) { *result = CHECK_NOTNULL(&valid_segments_[index]); }
-  return true;
-}
-
-Segment SegmentedCloud::getValidSegmentByIndex(const size_t index) const {
-  CHECK_LT(index, valid_segments_.size()) <<
-      "Attempted to access index out of bounds of valid_segments_";
-  return valid_segments_[index];
-}
-
-Segment* SegmentedCloud::getValidSegmentPtrByIndex(const size_t index) {
-  CHECK_LT(index, valid_segments_.size()) <<
-      "Attempted to access index out of bounds of valid_segments_";
-  return CHECK_NOTNULL(&valid_segments_[index]);
 }
 
 void SegmentedCloud::deleteSegmentsById(const std::vector<Id>& ids, size_t* n_removals) {
-  if (n_removals != NULL) { *n_removals = 0; }
-  for (size_t i = 0u; i < ids.size(); ++i) {
-    size_t index;
-    if (findValidSegmentById(ids.at(i), NULL, &index)) {
-      valid_segments_.erase(valid_segments_.begin() + index);
-      if (n_removals != NULL) { (*n_removals)++; }
+  if (n_removals != NULL) {
+    *n_removals = 0;
+  }
+  for (const auto& id: ids) {
+    valid_segments_.erase(id);
+    // TODO obsolete?
+    if (n_removals != NULL) {
+      (*n_removals)++;
     }
   }
 }
 
 void SegmentedCloud::calculateSegmentCentroids() {
-  for (size_t i = 0u; i < getNumberOfValidSegments(); ++i) {
-    getValidSegmentPtrByIndex(i)->calculateCentroid();
+  for (auto& segment: valid_segments_) {
+    segment.second.calculateCentroid();
   }
 }
 
 void SegmentedCloud::clear() {
   //TODO(Daniel): fill this function
   valid_segments_.clear();
-  small_segments_.clear();
-  large_segments_.clear();
 }
 
 PointICloud SegmentedCloud::validSegmentsAsPointCloud(
     std::vector<Id>* segment_id_for_each_point_ptr) const {
-  if (segment_id_for_each_point_ptr != NULL) { segment_id_for_each_point_ptr->clear(); }
+  if (segment_id_for_each_point_ptr != NULL) {
+    segment_id_for_each_point_ptr->clear();
+  }
   PointICloud result;
-  for (size_t i = 0u; i < getNumberOfValidSegments(); ++i) {
-    result += getValidSegmentByIndex(i).point_cloud;
+  for (const auto& id_segment: valid_segments_) {
+    result += id_segment.second.point_cloud;
     // Export the segment ids if desired.
     if (segment_id_for_each_point_ptr != NULL) {
-      for (size_t j = 0u; j < getValidSegmentByIndex(i).point_cloud.size(); ++j) {
-        segment_id_for_each_point_ptr->push_back(getValidSegmentByIndex(i).segment_id);
+      for (size_t j = 0u; j < id_segment.second.point_cloud.size(); ++j) {
+        segment_id_for_each_point_ptr->push_back(id_segment.first);
       }
       CHECK(segment_id_for_each_point_ptr->size() == result.size()) <<
           "Each point should have a single segment id.";
@@ -299,19 +255,48 @@ PointICloud SegmentedCloud::validSegmentsAsPointCloudFromIds(
 
 PointCloud SegmentedCloud::centroidsAsPointCloud(
     std::vector<Id>* segment_id_for_each_point_ptr) const {
-  if (segment_id_for_each_point_ptr != NULL) { segment_id_for_each_point_ptr->clear(); }
+  if (segment_id_for_each_point_ptr != NULL) {
+    segment_id_for_each_point_ptr->clear();
+  }
   PointCloud result;
-  for (size_t i = 0u; i < getNumberOfValidSegments(); ++i) {
-    result.push_back(getValidSegmentByIndex(i).centroid);
+  for (const auto& id_segment: valid_segments_) {
+    result.push_back(id_segment.second.centroid);
     // Export the segment ids if desired.
     if (segment_id_for_each_point_ptr != NULL) {
-      segment_id_for_each_point_ptr->push_back(getValidSegmentByIndex(i).segment_id);
+      segment_id_for_each_point_ptr->push_back(id_segment.first);
     }
   }
   if (segment_id_for_each_point_ptr != NULL) {
     CHECK(segment_id_for_each_point_ptr->size() == result.size()) <<
         "Each point should have a single segment id.";
   }
+  return result;
+}
+
+PointCloud SegmentedCloud::centroidsAsPointCloud(
+    const laser_slam::SE3& center, double maximum_linkpose_distance,
+    std::vector<Id>* segment_id_for_each_point_ptr) const {
+  if (segment_id_for_each_point_ptr != NULL) {
+    segment_id_for_each_point_ptr->clear();
+  }
+  PointCloud result;
+  for (const auto& id_segment: valid_segments_) {
+    Segment segment = id_segment.second;
+    if (laser_slam::distanceBetweenTwoSE3(segment.T_w_linkpose, center) <=
+        maximum_linkpose_distance) {
+      result.push_back(segment.centroid);
+      // Export the segment ids if desired.
+      if (segment_id_for_each_point_ptr != NULL) {
+        segment_id_for_each_point_ptr->push_back(segment.segment_id);
+      }
+    }
+  }
+  if (segment_id_for_each_point_ptr != NULL) {
+    CHECK(segment_id_for_each_point_ptr->size() == result.size()) <<
+        "Each point should have a single segment id.";
+  }
+  LOG(INFO) << "centroidsAsPointCloud returning " << result.size() << " from " <<
+      valid_segments_.size() << " segments.";
   return result;
 }
 
@@ -386,8 +371,10 @@ bool SegmentedCloud::computeSegmentOverlaps(const SegmentedCloud& target_segment
 
   // Loop over valid segments in this SegmentedCloud.
   const float overlap_radius_squared = overlap_radius * overlap_radius;
-  for (size_t i = 0u; i < getNumberOfValidSegments(); ++i) {
-    Segment current_segment = getValidSegmentByIndex(i);
+
+  unsigned int i = 0u;
+  for (const auto& id_segment: valid_segments_) {
+    Segment current_segment = id_segment.second;
     IdOccurences id_occurences_in_segment_overlap;
 
     // Find the nearest segments by centroid.
@@ -448,6 +435,7 @@ bool SegmentedCloud::computeSegmentOverlaps(const SegmentedCloud& target_segment
     } else {
       LOG(INFO) << "Worst offender for " << current_segment.segment_id << ": None.";
     }
+    ++i;
   }
 
   CHECK(overlaps->worst_offenders_.size() == getNumberOfValidSegments());
@@ -456,36 +444,36 @@ bool SegmentedCloud::computeSegmentOverlaps(const SegmentedCloud& target_segment
 }
 
 void SegmentedCloud::setTimeStampOfSegments(const laser_slam::Time& timestamp_ns) {
-  for (Segment& segment: valid_segments_) {
-    segment.timestamp_ns = timestamp_ns;
+  for (auto& id_segment: valid_segments_) {
+    id_segment.second.timestamp_ns = timestamp_ns;
   }
 }
 
 void SegmentedCloud::setLinkPoseOfSegments(const laser_slam::SE3& link_pose) {
-  for (Segment& segment: valid_segments_) {
-    segment.T_w_linkpose = link_pose;
+  for (auto& id_segment: valid_segments_) {
+    id_segment.second.T_w_linkpose = link_pose;
   }
 }
 
 void SegmentedCloud::setTrackId(unsigned int track_id) {
-  for (Segment& segment: valid_segments_) {
-    segment.track_id = track_id;
+  for (auto& id_segment: valid_segments_) {
+    id_segment.second.track_id = track_id;
   }
 }
 
 void SegmentedCloud::updateSegments(const std::vector<laser_slam::Trajectory>& trajectories) {
-  for (Segment& segment: valid_segments_) {
-    SE3 new_pose = trajectories.at(segment.track_id).at(segment.timestamp_ns);
+  for (auto& id_segment: valid_segments_) {
+    SE3 new_pose = trajectories.at(id_segment.second.track_id).at(id_segment.second.timestamp_ns);
 
-    SE3 transformation = new_pose * segment.T_w_linkpose.inverse();
+    SE3 transformation = new_pose * id_segment.second.T_w_linkpose.inverse();
     // Transform the point cloud.
-    transformPointCloud(transformation, &segment.point_cloud);
+    transformPointCloud(transformation, &id_segment.second.point_cloud);
 
     // Transform the segment centroid.
-    transformPclPoint(transformation, &segment.centroid);
+    transformPclPoint(transformation, &id_segment.second.centroid);
 
     // Update the link pose.
-    segment.T_w_linkpose = new_pose;
+    id_segment.second.T_w_linkpose = new_pose;
   }
 }
 


### PR DESCRIPTION
As discussed in #12, this is to make the filtering of duplicates more efficient. Using the unordered_map is indeed much quicker.