### PR TITLE
combined in exportSegmentsAndFeatures

### DIFF
--- a/segmatch/include/segmatch/database.hpp
+++ b/segmatch/include/segmatch/database.hpp
@@ -50,6 +50,8 @@ bool exportSegments(const std::string& filename,
                     const SegmentedCloud& segmented_cloud);
 bool exportFeatures(const std::string& filename,
                     const SegmentedCloud& segmented_cloud);
+bool exportSegmentsAndFeatures(const std::string& filename_prefix,
+                               const SegmentedCloud& segmented_cloud);
 bool exportMatches(const std::string& filename, const UniqueIdMatches& matches);
 
 bool importSegments(const std::string& filename,

--- a/segmatch/src/database.cpp
+++ b/segmatch/src/database.cpp
@@ -197,6 +197,12 @@ bool exportFeatures(const std::string& filename, const SegmentedCloud& segmented
   }
 }
 
+bool exportSegmentsAndFeatures(const std::string& filename_prefix,
+                               const SegmentedCloud& segmented_cloud) {
+  exportSegments(filename_prefix + "_segments.csv", segmented_cloud);
+  exportFeatures(filename_prefix + "_features.csv", segmented_cloud);
+}
+
 bool exportMatches(const std::string& filename, const UniqueIdMatches& matches) {
   ensureDirectoryExistsForFilename(filename);
   std::ofstream output_file;

--- a/segmatch_ros/src/segmatch_worker.cpp
+++ b/segmatch_ros/src/segmatch_worker.cpp
@@ -306,12 +306,10 @@ bool SegMatchWorker::exportRunServiceCall(std_srvs::Empty::Request& req,
   // Get current date.
   const boost::posix_time::ptime time_as_ptime = ros::WallTime::now().toBoost();
   std::string acquisition_time = to_iso_extended_string(time_as_ptime);
-  database::exportFeatures("/tmp/online_matcher/run_" + acquisition_time + "_features.csv",
-                            segments_database_);
-  database::exportSegments("/tmp/online_matcher/run_" + acquisition_time + "_segments.csv",
-                            segments_database_);
   database::exportMatches("/tmp/online_matcher/run_" + acquisition_time + "_matches.csv",
                            matches_database_);
+  database::exportSegmentsAndFeatures("/tmp/online_matcher/run_" + acquisition_time,
+                                      segments_database_);
   return true;
 }
 


### PR DESCRIPTION
@exodaniel I had a small bug where there were more segments than features. Most likely because the segments database was updated in the `processCloud()` function running in the thread. That should fix it. I also moved exporting the matches above just in case so that a match does not contain a segment which was not exported. What do you think?